### PR TITLE
Update to the latest ECR tag and make repo_tag a variable

### DIFF
--- a/terraform/collector/main.tf
+++ b/terraform/collector/main.tf
@@ -161,7 +161,7 @@ module "security_hub_collector_runner" {
   task_name                 = "scheduled-collector"
   repo_arn                  = "arn:aws:ecr:us-east-1:037370603820:repository/security-hub-collector"
   repo_url                  = "037370603820.dkr.ecr.us-east-1.amazonaws.com/security-hub-collector"
-  repo_tag                  = "d93a473"
+  repo_tag                  = var.repo_tag
   ecs_vpc_id                = var.ecs_vpc_id
   ecs_subnet_ids            = var.ecs_subnet_ids
   schedule_task_expression  = var.schedule_task_expression

--- a/terraform/collector/terraform.tfvars
+++ b/terraform/collector/terraform.tfvars
@@ -6,3 +6,4 @@ output_path                                = ""
 s3_key                                     = ""
 aws_cloudwatch_log_group_name              = "security_hub_collector"
 assign_public_ip                           = true
+repo_tag                                   = "92dc46c"

--- a/terraform/collector/variables.tf
+++ b/terraform/collector/variables.tf
@@ -37,3 +37,8 @@ variable "assign_public_ip" {
   description = "Whether to assign a public IP address to the ECS task"
   type        = bool
 }
+
+variable "repo_tag" {
+  description = "ECR Tag of the image to run in the ECS Task"
+  type        = string
+}


### PR DESCRIPTION
[CMCSMACD-2468](https://jiraent.cms.gov/browse/CMCSMACD-2468)

Tests:
Deployed the container and verified that it was running correctly