### PR TITLE
Upgrade CI versions and refactor Dockerfile to use scratch container

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,6 +1,8 @@
 name: validate
 on:
   pull_request:
+  push:
+    branches: [bharvey-ci]
 
 
 jobs:

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -17,7 +17,7 @@ jobs:
     - name: setup go
       uses: actions/setup-go@v2
       with:
-        go-version: 1.19
+        go-version: 1.22
 
     - name: setup python
       uses: actions/setup-python@v5.3.0

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -17,6 +17,8 @@ jobs:
 
     - name: setup python
       uses: actions/setup-python@v5.3.0
+      with:
+        python-version: 3.13
 
     - name: pre-commit-cache
       uses: actions/cache@v4.2.0

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4.2.2
       with:
         fetch-depth: 0
 
@@ -20,10 +20,10 @@ jobs:
         go-version: 1.19
 
     - name: setup python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5.3.0
 
     - name: pre-commit-cache
-      uses: actions/cache@v2
+      uses: actions/cache@v4.2.0
       env:
         cache-name: pre-commit-dot-cache
       with:
@@ -31,7 +31,7 @@ jobs:
         key: ${{ runner.os }}-${{ env.cache-name }}-${{ hashFiles('**/.pre-commit-config.yaml') }}
 
     - name: run pre-commit
-      uses: pre-commit/action@v2.0.3
+      uses: pre-commit/action@v3.0.1
 
     - name: run go tests
       run: go test -v ./pkg/...

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,9 +1,5 @@
 name: validate
-on:
-  pull_request:
-  push:
-    branches: [bharvey-ci]
-
+on: push
 
 jobs:
   validate:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,6 +1,5 @@
 linters-settings:
-  govet:
-    check-shadowing: true
+  govet: {}
   goimports:
     # put imports beginning with prefix after 3rd-party packages;
     # it's a comma-separated list of prefixes
@@ -8,18 +7,15 @@ linters-settings:
 
 linters:
   enable:
-    - deadcode
     - errcheck
     - gofmt
     - goimports
-    - golint
+    - revive
     - gosec
     - govet
     - ineffassign
     - staticcheck
-    - structcheck
     - typecheck
-    - varcheck
   disable:
     - gosimple #deprecated https://github.com/golangci/golangci-lint/issues/357
     - unused #deprecated https://github.com/dominikh/go-tools/tree/master/cmd/unused

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,4 +24,5 @@ repos:
   - repo: https://github.com/hadolint/hadolint
     rev: v2.12.0
     hooks:
-      - id: hadolint
+      - id: hadolint-docker
+        entry: hadolint/hadolint:latest hadolint

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/golangci/golangci-lint
-    rev: v1.48.0
+    rev: v1.63.4
     hooks:
       - id: golangci-lint
 
@@ -17,12 +17,11 @@ repos:
       - id: trailing-whitespace
 
   - repo: https://github.com/igorshubovych/markdownlint-cli
-    rev: v0.26.0
+    rev: v0.43.0
     hooks:
       - id: markdownlint
 
-  - repo: https://github.com/pryorda/dockerfilelint-precommit-hooks
-    rev: v0.1.0
+  - repo: https://github.com/hadolint/hadolint
+    rev: v2.12.0
     hooks:
-      - id: dockerfilelint
-        stages: [commit]
+      - id: hadolint

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,7 +5,7 @@ repos:
       - id: golangci-lint
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v3.4.0
+    rev: v5.0.0
     hooks:
       - id: check-json
       - id: check-merge-conflict

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -59,7 +59,7 @@ representative at an online or offline event.
 ## Enforcement
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported to the community leaders responsible for enforcement at oss-coc@truss.works.
+reported to the community leaders responsible for enforcement.
 All complaints will be reviewed and investigated promptly and fairly.
 
 All community leaders are obligated to respect the privacy and security of the

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,4 @@
 FROM golang:1.21 as build
-COPY ./docker-gitconfig /root/.gitconfig
 WORKDIR /build
 COPY . .
 RUN CGO_ENABLED=0 GOBIN=/bin/ go install .

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,8 @@
 FROM golang:1.19-alpine
-RUN apk add --no-cache bash
-COPY . /build
-RUN cd /build; CGO_ENABLED=0 GOBIN=/bin/ go install .
-COPY scriptRunner.sh scriptRunner.sh
+RUN apk add --no-cache bash=5.2.15-r5
+WORKDIR /build
+COPY . .
+RUN CGO_ENABLED=0 GOBIN=/bin/ go install .
+WORKDIR /app
+COPY scriptRunner.sh .
 ENTRYPOINT ["./scriptRunner.sh"]


### PR DESCRIPTION
This change 
- bumps the version of most of the pre-commit and other checks. I also chose a different Dockerfile linter because the one Truss chose had 12 stars and zero activity in the past 2 years 😐 while the new one has 10k stars and an issue closed in the past month
- updates the Dockerfile to fix a few warnings generated by the new linter
- fixes a few other things found by the bumped versions
- runs the validation checks on every push (instead of just on PR) because that's our team standard. 

Testing: 
- built and ran the updated Dockerfile
- updated workflow runs successfully