### PR TITLE
Fix more parsing issues

### DIFF
--- a/pkg/securityhubcollector/security_hub_collector.go
+++ b/pkg/securityhubcollector/security_hub_collector.go
@@ -215,25 +215,26 @@ func (h *HubCollector) convertFindingToRows(finding types.AwsSecurityFinding, te
 			region = *finding.Region
 		}
 
+		// Create record with all string fields sanitized
 		record := FindingRecord{
-			Team:          teamName,
-			ResourceType:  *r.Type,
-			Title:         *finding.Title,
+			Team:          sanitizeFieldForCSV(teamName),
+			ResourceType:  sanitizeFieldForCSV(*r.Type),
+			Title:         sanitizeFieldForCSV(*finding.Title),
 			Description:   sanitizeFieldForCSV(*finding.Description),
-			ResourceID:    *r.Id,
-			AWSAccountID:  *finding.AwsAccountId,
-			RecordState:   string(finding.RecordState),
-			CreatedAt:     standardizeTimestamp(*finding.CreatedAt),
-			UpdatedAt:     standardizeTimestamp(*finding.UpdatedAt),
-			Region:        region,
-			Environment:   environment,
-			Product:       *finding.ProductName,
-			DateCollected: clock.Now().Format("01-02-2006"),
+			ResourceID:    sanitizeFieldForCSV(*r.Id),
+			AWSAccountID:  sanitizeFieldForCSV(*finding.AwsAccountId),
+			RecordState:   sanitizeFieldForCSV(string(finding.RecordState)),
+			CreatedAt:     standardizeTimestamp(*finding.CreatedAt), // Timestamps don't need sanitization
+			UpdatedAt:     standardizeTimestamp(*finding.UpdatedAt), // Timestamps don't need sanitization
+			Region:        sanitizeFieldForCSV(region),
+			Environment:   sanitizeFieldForCSV(environment),
+			Product:       sanitizeFieldForCSV(*finding.ProductName),
+			DateCollected: clock.Now().Format("01-02-2006"), // Generated date format doesn't need sanitization
 		}
 
-		// Handle fields that might be nil
+		// Handle optional fields with nil checks
 		if finding.Severity != nil {
-			record.SeverityLabel = string(finding.Severity.Label)
+			record.SeverityLabel = sanitizeFieldForCSV(string(finding.Severity.Label))
 		}
 
 		if finding.Remediation != nil && finding.Remediation.Recommendation != nil {
@@ -241,16 +242,16 @@ func (h *HubCollector) convertFindingToRows(finding types.AwsSecurityFinding, te
 				record.RemediationText = sanitizeFieldForCSV(*finding.Remediation.Recommendation.Text)
 			}
 			if finding.Remediation.Recommendation.Url != nil {
-				record.RemediationURL = *finding.Remediation.Recommendation.Url
+				record.RemediationURL = sanitizeFieldForCSV(*finding.Remediation.Recommendation.Url)
 			}
 		}
 
 		if finding.Compliance != nil {
-			record.ComplianceStatus = string(finding.Compliance.Status)
+			record.ComplianceStatus = sanitizeFieldForCSV(string(finding.Compliance.Status))
 		}
 
 		if finding.Workflow != nil {
-			record.WorkflowStatus = string(finding.Workflow.Status)
+			record.WorkflowStatus = sanitizeFieldForCSV(string(finding.Workflow.Status))
 		}
 
 		output = append(output, record.ToSlice())

--- a/pkg/securityhubcollector/security_hub_collector.go
+++ b/pkg/securityhubcollector/security_hub_collector.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"log"
 	"path/filepath"
+	"reflect"
+	"strings"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -24,6 +26,20 @@ import (
 type HubCollector struct {
 	outputFile *os.File
 	csvWriter  *csv.Writer
+}
+
+// call this on fields that have control characters that might break CSV parsing in QuickSight
+func sanitizeFieldForCSV(field string) string {
+	var builder strings.Builder
+	builder.Grow(len(field))
+	for _, r := range field {
+		if r >= 32 && r <= 126 {
+			builder.WriteRune(r) // Keep printable ASCII
+		} else {
+			builder.WriteRune(' ') // Everything else becomes space
+		}
+	}
+	return strings.TrimSpace(builder.String())
 }
 
 func standardizeTimestamp(timestamp string) string {
@@ -136,78 +152,108 @@ func (h *HubCollector) GetFindingsAndWriteToOutput(secHubRegion, teamName string
 	return nil
 }
 
+type FindingRecord struct {
+	Team             string `csv:"Team"`
+	ResourceType     string `csv:"Resource Type"`
+	Title            string `csv:"Title"`
+	Description      string `csv:"Description"`
+	SeverityLabel    string `csv:"Severity Label"`
+	RemediationText  string `csv:"Remediation Text"`
+	RemediationURL   string `csv:"Remediation URL"`
+	ResourceID       string `csv:"Resource ID"`
+	AWSAccountID     string `csv:"AWS Account ID"`
+	ComplianceStatus string `csv:"Compliance Status"`
+	RecordState      string `csv:"Record State"`
+	WorkflowStatus   string `csv:"Workflow Status"`
+	CreatedAt        string `csv:"Created At"`
+	UpdatedAt        string `csv:"Updated At"`
+	Region           string `csv:"Region"`
+	Environment      string `csv:"Environment"`
+	Product          string `csv:"Product"`
+	DateCollected    string `csv:"Date Collected"`
+}
+
+// GetHeaders returns a slice of header names from the CSV tags of the struct fields.
+// If a field doesn't have a CSV tag, it falls back to using the field name.
+func (FindingRecord) GetHeaders() []string {
+	t := reflect.TypeOf(FindingRecord{})
+	headers := make([]string, t.NumField())
+
+	for i := 0; i < t.NumField(); i++ {
+		field := t.Field(i)
+		if csvHeader := field.Tag.Get("csv"); csvHeader != "" {
+			headers[i] = csvHeader
+		} else {
+			headers[i] = field.Name
+		}
+	}
+
+	return headers
+}
+
+func (r FindingRecord) ToSlice() []string {
+	v := reflect.ValueOf(r)
+	slice := make([]string, v.NumField())
+
+	for i := 0; i < v.NumField(); i++ {
+		fieldValue := v.Field(i)
+		slice[i] = fieldValue.String()
+	}
+
+	return slice
+}
+
 // convertFindingToRows - converts a single finding to the record format we're using
-// the order of the records must match with the order of the headers in writeHeadersToOutput
 func (h *HubCollector) convertFindingToRows(finding types.AwsSecurityFinding, teamName, environment string, clock clock.Clock) [][]string {
 	var output [][]string
 
-	// Each finding may have multiple resources, so we need to iterate through
-	// them and pull the relevant bits; we will create two lines for a single
-	// finding that has two resources, with only the resource different.
 	for _, r := range finding.Resources {
-		// Here we compile a single record, which is a representation of
-		// the row we want to output into the CSV for this resource in
-		// the finding.
-
-		// If the resource for a finding has a non-nil region, prefer that. Otherwise use the finding region.  If both are nil, use an empty string.
-		var region string
+		region := ""
 		if r.Region != nil {
 			region = *r.Region
 		} else if finding.Region != nil {
 			region = *finding.Region
 		}
 
-		var record []string
-		record = append(record, teamName)
-		record = append(record, *r.Type)
-		record = append(record, *finding.Title)
-		record = append(record, *finding.Description)
-		if finding.Severity == nil {
-			record = append(record, "")
-		} else {
-			record = append(record, string(finding.Severity.Label))
+		record := FindingRecord{
+			Team:          teamName,
+			ResourceType:  *r.Type,
+			Title:         *finding.Title,
+			Description:   sanitizeFieldForCSV(*finding.Description),
+			ResourceID:    *r.Id,
+			AWSAccountID:  *finding.AwsAccountId,
+			RecordState:   string(finding.RecordState),
+			CreatedAt:     standardizeTimestamp(*finding.CreatedAt),
+			UpdatedAt:     standardizeTimestamp(*finding.UpdatedAt),
+			Region:        region,
+			Environment:   environment,
+			Product:       *finding.ProductName,
+			DateCollected: clock.Now().Format("01-02-2006"),
 		}
-		if finding.Remediation == nil {
-			record = append(record, "", "")
-		} else {
-			if finding.Remediation.Recommendation == nil {
-				record = append(record, "", "")
-			} else {
-				if finding.Remediation.Recommendation.Text == nil {
-					record = append(record, "")
-				} else {
-					record = append(record, *finding.Remediation.Recommendation.Text)
-				}
-				if finding.Remediation.Recommendation.Url == nil {
-					record = append(record, "")
-				} else {
-					record = append(record, *finding.Remediation.Recommendation.Url)
-				}
+
+		// Handle fields that might be nil
+		if finding.Severity != nil {
+			record.SeverityLabel = string(finding.Severity.Label)
+		}
+
+		if finding.Remediation != nil && finding.Remediation.Recommendation != nil {
+			if finding.Remediation.Recommendation.Text != nil {
+				record.RemediationText = sanitizeFieldForCSV(*finding.Remediation.Recommendation.Text)
+			}
+			if finding.Remediation.Recommendation.Url != nil {
+				record.RemediationURL = *finding.Remediation.Recommendation.Url
 			}
 		}
-		record = append(record, *r.Id)
-		record = append(record, *finding.AwsAccountId)
-		if finding.Compliance == nil {
-			record = append(record, "")
-		} else {
-			record = append(record, string(finding.Compliance.Status))
-		}
-		record = append(record, string(finding.RecordState))
-		if finding.Workflow == nil {
-			record = append(record, "")
-		} else {
-			record = append(record, string(finding.Workflow.Status))
-		}
-		record = append(record, standardizeTimestamp(*finding.CreatedAt))
-		record = append(record, standardizeTimestamp(*finding.UpdatedAt))
-		record = append(record, region)
-		record = append(record, environment)
-		record = append(record, *finding.ProductName)
-		record = append(record, clock.Now().Format("01-02-2006"))
 
-		// Each record *may* have multiple findings, so we make a list of
-		// records and that's what we'll output.
-		output = append(output, record)
+		if finding.Compliance != nil {
+			record.ComplianceStatus = string(finding.Compliance.Status)
+		}
+
+		if finding.Workflow != nil {
+			record.WorkflowStatus = string(finding.Workflow.Status)
+		}
+
+		output = append(output, record.ToSlice())
 	}
 
 	return output
@@ -218,19 +264,7 @@ func (h *HubCollector) writeHeadersToOutput() error {
 	if !h.isInitialized() {
 		return fmt.Errorf("HubCollector is not initialized")
 	}
-
-	// For now, we're hardcoding the headers; in the future, if it turned
-	// out the data we wanted from these findings changed regularly, we
-	// could make the headers/fields come from some sort of schema or struct,
-	// but for now this is good enough.
-	headers := []string{"Team", "Resource Type", "Title", "Description", "Severity Label", "Remediation Text", "Remediation URL", "Resource ID", "AWS Account ID", "Compliance Status", "Record State", "Workflow Status", "Created At", "Updated At", "Region", "Environment", "Product", "Date Collected"}
-
-	err := h.csvWriter.Write(headers)
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return h.csvWriter.Write(FindingRecord{}.GetHeaders())
 }
 
 // writeFindingsToOutput - takes a list of security findings and writes them to the output file.

--- a/terraform/collector/terraform.tfvars
+++ b/terraform/collector/terraform.tfvars
@@ -1,7 +1,7 @@
 ecs_vpc_id                                 = "vpc-07f4de56f6970729d"
 ecs_subnet_ids                             = ["subnet-06bbdc0b680091dd1", "subnet-02d08271e8ac413b0"]
 security_hub_collector_results_bucket_name = "securityhub-collector-results-037370603820s"
-schedule_task_expression                   = "cron(50 * ? * * *)"
+schedule_task_expression                   = "cron(35 * ? * * *)"
 aws_cloudwatch_log_group_name              = "security_hub_collector"
 assign_public_ip                           = true
 repo_tag                                   = "b6f8272"

--- a/terraform/collector/terraform.tfvars
+++ b/terraform/collector/terraform.tfvars
@@ -1,7 +1,7 @@
 ecs_vpc_id                                 = "vpc-07f4de56f6970729d"
 ecs_subnet_ids                             = ["subnet-06bbdc0b680091dd1", "subnet-02d08271e8ac413b0"]
 security_hub_collector_results_bucket_name = "securityhub-collector-results-037370603820s"
-schedule_task_expression                   = "cron(35 * ? * * *)"
+schedule_task_expression                   = "cron(49 * ? * * *)"
 aws_cloudwatch_log_group_name              = "security_hub_collector"
 assign_public_ip                           = true
-repo_tag                                   = "7003152"
+repo_tag                                   = "491bc58"

--- a/terraform/collector/terraform.tfvars
+++ b/terraform/collector/terraform.tfvars
@@ -1,7 +1,7 @@
 ecs_vpc_id                                 = "vpc-07f4de56f6970729d"
 ecs_subnet_ids                             = ["subnet-06bbdc0b680091dd1", "subnet-02d08271e8ac413b0"]
 security_hub_collector_results_bucket_name = "securityhub-collector-results-037370603820s"
-schedule_task_expression                   = "cron(49 * ? * * *)"
+schedule_task_expression                   = "cron(50 * ? * * *)"
 aws_cloudwatch_log_group_name              = "security_hub_collector"
 assign_public_ip                           = true
-repo_tag                                   = "491bc58"
+repo_tag                                   = "b6f8272"


### PR DESCRIPTION
There were still parsing issues after https://github.com/Enterprise-CMCS/mac-fc-security-hub-collector/pull/31. We don't have any control over the content of the SecHub finding fields or any wacky characters that end up there, so this change strips all non-printable characters (control characters) out of all fields and replaces them with spaces. It's a sacrifice of readability, but for the current use case it doesn't matter because the QuickSight dashboard format doesn't respect things like newlines anyway.

I also refactored the code for writing headers and rows to use reflection, because the way Truss set it up was hard to read and maintain. 

Testing: 
- ran locally against the problem account (MACFin), pushed to S3, and ingested with no errors or skipped rows
- built image, ran scheduled task against all accounts, ingested with no errors or skipped rows