### PR TITLE
Terraform changes to replace Athena with Teams API

### DIFF
--- a/terraform/collector/terraform.tfvars
+++ b/terraform/collector/terraform.tfvars
@@ -4,4 +4,5 @@ security_hub_collector_results_bucket_name = "securityhub-collector-results-0373
 schedule_task_expression                   = "cron(35 * ? * * *)"
 aws_cloudwatch_log_group_name              = "security_hub_collector"
 assign_public_ip                           = true
-repo_tag                                   = "b6f8272"
+repo_tag                                   = "5a42dfb"
+execute_api_vpc_endpoint_security_group_id = "sg-091693499ea7af4e2"

--- a/terraform/collector/variables.tf
+++ b/terraform/collector/variables.tf
@@ -32,3 +32,8 @@ variable "repo_tag" {
   description = "ECR Tag of the image to run in the ECS Task"
   type        = string
 }
+
+variable "execute_api_vpc_endpoint_security_group_id" {
+  description = "To allow the collector to call the Teams API via the execute-api VPC endpoint"
+  type        = string
+}


### PR DESCRIPTION
https://jiraent.cms.gov/browse/CMCSMACD-3457

Adopts the Docker image and "ECS runner module" versions that support the Teams API. Includes other infrastructure to support the Teams API switch.

Tested:
- `terraform apply`
- Verified that the Security Hub Collector succeeds and the file appears on S3