### PR TITLE
remove sorted keys requirement in pre-commit pretty-format-json check

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,6 +14,7 @@ repos:
       - id: pretty-format-json
         args:
           - --autofix
+          - --no-sort-keys
       - id: trailing-whitespace
 
   - repo: https://github.com/igorshubovych/markdownlint-cli


### PR DESCRIPTION
generate-codejson.yml provided by OSPO and used
for ShareIT compliance, does not have sorted keys