### PR TITLE
update task to use image with tag f0cecba

### DIFF
--- a/terraform/collector/.terraform.lock.hcl
+++ b/terraform/collector/.terraform.lock.hcl
@@ -6,6 +6,7 @@ provider "registry.terraform.io/hashicorp/aws" {
   constraints = "~> 6.0"
   hashes = [
     "h1:79RHpchB+IjuZLMNkbCSjkguoAOUsSWnr0N6Bei+PxI=",
+    "h1:B7X8EU6aZ9KzIvP0VBDhhgadgjXIrUgMXt/pJ6EUXvo=",
     "zh:038fd943de79acd9f9f73106fa0eba588c6a0d4e0993e146f51f3aa043728c5f",
     "zh:06fa0177d33d3d3f9cb7e205fbeb1c4c3095ba637e2b4d292429401ec5612e81",
     "zh:212714fc8b6ee57e26d11d0fdf2ecfe23b37a6eac1008b399c1d790528c3f072",

--- a/terraform/collector/terraform.tfvars
+++ b/terraform/collector/terraform.tfvars
@@ -4,5 +4,5 @@ security_hub_collector_results_bucket_name = "securityhub-collector-results-0373
 schedule_task_expression                   = "cron(35 * ? * * *)"
 aws_cloudwatch_log_group_name              = "security_hub_collector"
 assign_public_ip                           = true
-repo_tag                                   = "31df896"
+repo_tag                                   = "f0cecba"
 execute_api_vpc_endpoint_security_group_id = "sg-091693499ea7af4e2"


### PR DESCRIPTION
https://jiraent.cms.gov/browse/CMCSMACD-6112
Use this image, which forces the collector to skip over MDT RHTP accounts.

Tested:
ran `terraform plan` and saw 1 task def destroyed/created.