### PR TITLE
Revert "security-hub-collector: skip 98826734 (MDCT RHTP accounts

### DIFF
--- a/pkg/teams/teams.go
+++ b/pkg/teams/teams.go
@@ -19,14 +19,6 @@ var seaToolAccountIDs = []string{
 	"635526538414",
 }
 
-// The MDCT RHTP accounts are in the Teams API team data (because we get CUR data from them)
-// but not in the MACBIS OU, so our cloud rule doesn't push the cross account role to them
-var mdctRHTPIDs = []string{
-	"823615568263", // Prod
-	"988267347373", // Impl
-	"793491548407", // Dev
-}
-
 type duplicateAccountIDError struct {
 	message string
 }
@@ -104,11 +96,6 @@ func GetTeamsFromTeamsAPI(baseURL string, apiKey string, rolePath string) (map[A
 
 			// skip SEATool accounts
 			if slices.Contains(seaToolAccountIDs, acct.ID) {
-				continue
-			}
-
-			// skip MDCT RHTP accounts
-			if slices.Contains(mdctRHTPIDs, acct.ID) {
 				continue
 			}
 


### PR DESCRIPTION
https://jiraent.cms.gov/browse/CMCSMACD-6139

This reverts commit f0cecba6f7008d8ece2070e997023e6b645caa63.

MDCT-RHTP AWS accounts (dev, impl, prod) are now in OU 141. 
The security-hub-collector can scan them again.
The CLDSPT ticket that moved these accounts into OU 141 is https://jiraent.cms.gov/browse/CLDSPT-104556

Tested:
I verified the cost-usage role is in these AWS accounts.