### PR TITLE
use latest ca-certificates (rather than a pinned version)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,3 +27,4 @@ repos:
     hooks:
       - id: hadolint-docker
         entry: hadolint/hadolint:latest hadolint
+        args: [--ignore, DL3018]

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ COPY . .
 RUN CGO_ENABLED=0 go build -o /bin/security-hub-collector .
 
 FROM alpine:3.22 AS certs
-RUN apk --no-cache add ca-certificates=20250911-r0
+RUN apk --no-cache add ca-certificates
 
 FROM scratch
 COPY --from=build /bin/security-hub-collector /bin/security-hub-collector


### PR DESCRIPTION
https://jiraent.cms.gov/browse/CMCSMACD-6141
The certificate was pinned to a version that was removed from alpine:3.22.
This PR uses the latest ca-certificates.

I had to ignore DL3018 in the hadolint linter.