### PR TITLE
use f52b896 repo tag so security-hub-collector scans MDCT RHTP

### DIFF
--- a/terraform/collector/terraform.tfvars
+++ b/terraform/collector/terraform.tfvars
@@ -4,5 +4,5 @@ security_hub_collector_results_bucket_name = "securityhub-collector-results-0373
 schedule_task_expression                   = "cron(35 * ? * * *)"
 aws_cloudwatch_log_group_name              = "security_hub_collector"
 assign_public_ip                           = true
-repo_tag                                   = "f0cecba"
+repo_tag                                   = "f52b896"
 execute_api_vpc_endpoint_security_group_id = "sg-091693499ea7af4e2"


### PR DESCRIPTION
https://jiraent.cms.gov/browse/CMCSMACD-6142

I successfully ran `terraform apply`.

Tested:
Checked the security-hub-collector logs.
<img width="1218" height="460" alt="image" src="https://github.com/user-attachments/assets/86bdb854-c768-4113-bf20-6d62847f1aad" />
<img width="1197" height="437" alt="image" src="https://github.com/user-attachments/assets/bc263b77-18a7-4bf3-95b9-4e31f7bc80d7" />

<img width="1250" height="367" alt="image" src="https://github.com/user-attachments/assets/4b540570-08ba-413b-961f-e47645ff186e" />
