### PR TITLE
update actions versions

### DIFF
--- a/.github/workflows/build-and-push-dev.yml
+++ b/.github/workflows/build-and-push-dev.yml
@@ -33,7 +33,7 @@ jobs:
 
       - name: Generate token from GitHub App
         id: create_token
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@v3
         with:
           app-id: ${{ secrets.APP_ID }}
           private-key: ${{ secrets.APP_PEM }}

--- a/.github/workflows/build-and-push-dev.yml
+++ b/.github/workflows/build-and-push-dev.yml
@@ -35,7 +35,7 @@ jobs:
         id: create_token
         uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ secrets.APP_ID }}
+          client-id: ${{ secrets.APP_ID }}
           private-key: ${{ secrets.APP_PEM }}
           owner: Enterprise-CMCS
 

--- a/.github/workflows/generate-codejson.yml
+++ b/.github/workflows/generate-codejson.yml
@@ -8,13 +8,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
       - name: Generate token from GitHub App
         id: create_token
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@v3
         with:
           app-id: ${{ secrets.PR_PERMS_APP_ID }}
           private-key: ${{ secrets.PR_PERMS_APP_SECRET }}

--- a/.github/workflows/generate-codejson.yml
+++ b/.github/workflows/generate-codejson.yml
@@ -16,7 +16,7 @@ jobs:
         id: create_token
         uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ secrets.PR_PERMS_APP_ID }}
+          client-id: ${{ secrets.PR_PERMS_APP_ID }}
           private-key: ${{ secrets.PR_PERMS_APP_SECRET }}
           owner: Enterprise-CMCS
 

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -13,11 +13,12 @@ jobs:
     - name: setup go
       uses: actions/setup-go@v6
       with:
-        go-version-file: go.mod
+        go-version: 'stable'
+        check-latest: true
 
     - name: Generate token from GitHub App
       id: create_token
-      uses: actions/create-github-app-token@v2
+      uses: actions/create-github-app-token@v3
       with:
         app-id: ${{ secrets.APP_ID }}
         private-key: ${{ secrets.APP_PEM }}

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -13,8 +13,7 @@ jobs:
     - name: setup go
       uses: actions/setup-go@v6
       with:
-        go-version: 'stable'
-        check-latest: true
+        go-version-file: go.mod
 
     - name: Generate token from GitHub App
       id: create_token

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -20,7 +20,7 @@ jobs:
       id: create_token
       uses: actions/create-github-app-token@v3
       with:
-        app-id: ${{ secrets.APP_ID }}
+        client-id: ${{ secrets.APP_ID }}
         private-key: ${{ secrets.APP_PEM }}
         owner: Enterprise-CMCS
 


### PR DESCRIPTION
https://jiraent.cms.gov/browse/CMCSMACD-6149
Update actions versions to address warnings:
Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: actions/checkout@v4, 
actions/create-github-app-token@v2, 
aws-actions/configure-aws-credentials@v4