### PR TITLE
Don't fail collection unless all accounts fail

### DIFF
--- a/main.go
+++ b/main.go
@@ -111,7 +111,7 @@ func collectFindings(secHubRegions []string) error {
 	defer func() {
 		ferr := h.FlushAndClose()
 		if ferr != nil {
-			log.Fatalf("could not flush buffer and close output file: %v", err)
+			log.Fatalf("could not flush buffer and close output file: %v", ferr)
 		}
 	}()
 
@@ -130,14 +130,22 @@ func collectFindings(secHubRegions []string) error {
 		}
 	}
 
+	var failures int
 	for account, teamName := range accountsToTeams {
 		for _, secHubRegion := range secHubRegions {
 			log.Printf("getting findings for account %v in %v", account.ID, secHubRegion)
-			err = h.GetFindingsAndWriteToOutput(secHubRegion, teamName, account)
+			err := h.GetFindingsAndWriteToOutput(secHubRegion, teamName, account)
 			if err != nil {
-				log.Fatalf("could not get findings for account %v in %v: %v", account.ID, secHubRegion, err)
+				log.Printf("could not get findings for account %v in %v: %v", account.ID, secHubRegion, err)
+				failures++
 			}
 		}
+	}
+	if failures > 0 {
+		log.Printf("failed to collect findings for %d of %d account/region pairs", failures, len(accountsToTeams)*len(secHubRegions))
+	}
+	if failures == len(accountsToTeams)*len(secHubRegions) {
+		return fmt.Errorf("could not collect findings for any account")
 	}
 
 	return nil


### PR DESCRIPTION
An issue with a single account has been causing the whole program to fail and write no rows, even for the non-failing accounts, causing alert noise. 

This changes the program behavior so that per-account failures don't fail the program, with an exception for the case where every account fails individually. In this case, there's some systemic problem and the program has performed no meaningful work, so it fails. We monitor program failures so we'll get an alert in this case. 

This approach introduces potential issues with data quality for persistent failures on a subset of accounts, since they won't get rows written. We'll address this issue in a more comprehensive way in a follow-up change. 

Testing: 
Ran the program locally with a team map that contained:
- one failing account and one successful account. The program logged for the failing account, wrote rows for the successful account, and exited 0.
- one failing account. The program exited 1.